### PR TITLE
Due to the change of the Firewall Rule

### DIFF
--- a/setup_mysql.sh
+++ b/setup_mysql.sh
@@ -144,8 +144,7 @@ function CreateFlexibleMySQLInstance() {
       -g $MYSQL_RES_GRP_NAME \
       -n $MYSQL_SERVER_NAME \
       -r AllowAllAzureIPs \
-      --start-ip-address 0.0.0.0 \
-      --end-ip-address 255.255.255.255
+      --start-ip-address 0.0.0.0 
   echo "Added Firewall Rule for Azure Address"
 }
 


### PR DESCRIPTION
If I only "--start-ip-address 0.0.0.0 " specify, it is possible to access from Azure Resources only which was wrote on following URL. And it means it was not "255.255.255.255".

https://docs.microsoft.com/en-us/cli/azure/mysql/flexible-server/firewall-rule?view=azure-cli-latest#az_mysql_flexible_server_firewall_rule_create

--start-ip-address
The start IP address of the firewall rule. Must be IPv4 format. Use value '0.0.0.0' to represent all Azure-internal IP addresses.